### PR TITLE
Fix for Sage Seeds dropping while using Modded Shears

### DIFF
--- a/src/main/resources/data/hexerei/loot_modifiers/sage_seeds_from_grass.json
+++ b/src/main/resources/data/hexerei/loot_modifiers/sage_seeds_from_grass.json
@@ -1,4 +1,3 @@
-
 {
   "type": "hexerei:sage_seeds_from_grass",
   "conditions": [
@@ -15,9 +14,7 @@
       "term":  {
         "condition": "minecraft:match_tool",
         "predicate": {
-          "items": [
-            "minecraft:shears"
-          ]
+          "tag": "forge:shears"
         }
       }
     }

--- a/src/main/resources/data/hexerei/loot_modifiers/sage_seeds_from_tall_grass.json
+++ b/src/main/resources/data/hexerei/loot_modifiers/sage_seeds_from_tall_grass.json
@@ -1,4 +1,3 @@
-
 {
   "type": "hexerei:sage_seeds_from_grass",
   "conditions": [
@@ -15,9 +14,7 @@
       "term":  {
         "condition": "minecraft:match_tool",
         "predicate": {
-          "items": [
-            "minecraft:shears"
-          ]
+          "tag": "forge:shears"
         }
       }
     }


### PR DESCRIPTION
### Issue Description
While using modded shears, Sage Seeds still can drop, because of the way loot modifiers are made 😅

### Fix Description
Change predicate from Items to Tag, to allow modded Shears to work as intended 😄
PS: This issue does affect 1.18.2 version of the mod as well, if you want me to make a PR there as well, just let me know!