### PR TITLE
fix: crash with oculus

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,4 +4,3 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 mixingradle_version = 0.7-SNAPSHOT
 mixin_version = 0.8.5
-org.gradle.java.home=C:/Program Files/Eclipse Adoptium/jdk-17.0.3.7-hotspot

--- a/src/main/java/net/joefoxe/hexerei/item/custom/HexereiBookItemRenderer.java
+++ b/src/main/java/net/joefoxe/hexerei/item/custom/HexereiBookItemRenderer.java
@@ -189,14 +189,14 @@ public class HexereiBookItemRenderer extends CustomItemRendererWithPageDrawing {
             if (tileEntityIn.degreesOpened != 90) {
                 try {
 
-                    drawPages(tileEntityIn, matrixStackIn, (MultiBufferSource.BufferSource) bufferIn, combinedLightIn, combinedOverlayIn, true, transformType, 0);
+                    drawPages(tileEntityIn, matrixStackIn, bufferIn, combinedLightIn, combinedOverlayIn, true, transformType, 0);
                 } catch (CommandSyntaxException e) {
                     e.printStackTrace();
                 }
             }
             else{
 
-                drawBaseButtons(tileEntityIn, matrixStackIn, (MultiBufferSource.BufferSource) bufferIn, combinedLightIn, combinedOverlayIn, false, false, tag.getInt("chapter"), tag.getInt("page"), true, transformType, true);
+                drawBaseButtons(tileEntityIn, matrixStackIn, bufferIn, combinedLightIn, combinedOverlayIn, false, false, tag.getInt("chapter"), tag.getInt("page"), true, transformType, true);
             }
 
 //            this.itemRenderer = Minecraft.getInstance().getItemRenderer();

--- a/src/main/resources/META-INF/accesstransformer.cfg
+++ b/src/main/resources/META-INF/accesstransformer.cfg
@@ -47,8 +47,6 @@ public-f net.minecraft.client.gui.screens.inventory.tooltip.ClientTextTooltip f_
 public-f net.minecraft.client.gui.Font$StringRenderOutput  # class
 public-f net.minecraft.client.renderer.GameRenderer f_109066_ # fov
 public-f net.minecraft.client.renderer.GameRenderer f_109067_ # oldFov
-public-f net.minecraft.world.entity.Entity m_7378_(Lnet/minecraft/nbt/CompoundTag;)V # readAdditionalSaveData
-
 
 
 #

--- a/src/main/resources/hexerei.mixin.json
+++ b/src/main/resources/hexerei.mixin.json
@@ -1,19 +1,17 @@
 {
-  "required": true,
-  "package": "net.joefoxe.hexerei.mixin",
-  "compatibilityLevel": "JAVA_17",
-  "refmap": "hexerei.mixin-refmap.json",
-  "client": [
-    "HumanoidArmorLayerMixin",
-    "PlayerItemInHandLayerMixin",
-    "ThirdPersonRendererMixin",
-    "MouseHandlerMixin",
-    "ItemInHandMixin"
-  ],
-  "mixins": [
-  ],
-  "injectors": {
-    "defaultRequire": 1
-  },
-  "minVersion": "0.8"
+    "required": true,
+    "package": "net.joefoxe.hexerei.mixin",
+    "compatibilityLevel": "JAVA_17",
+    "refmap": "hexerei.mixin-refmap.json",
+    "client": [
+        "HumanoidArmorLayerMixin",
+        "ItemInHandMixin",
+        "MouseHandlerMixin",
+        "PlayerItemInHandLayerMixin",
+        "ThirdPersonRendererMixin"
+    ],
+    "injectors": {
+        "defaultRequire": 1
+    },
+    "minVersion": "0.8"
 }


### PR DESCRIPTION
Change the usage of `MultiBufferSource.BufferSource` to `MultiBufferSource`

This fix should work for 1.19+. But this PR is for 1.18.2

https://pastes.dev/6kILatoqwD
https://pastes.dev/ogPktZyer9
https://pastes.dev/pbI6ZFkdGI

fix #40
fix #45