### PR TITLE
Adds Hexerei Chests to the Forge Block and Item Tags

### DIFF
--- a/src/main/resources/data/forge/tags/blocks/chests.json
+++ b/src/main/resources/data/forge/tags/blocks/chests.json
@@ -1,0 +1,8 @@
+{
+    "replace": false,
+    "values": [
+      "hexerei:mahogany_window_chest",
+      "hexerei:willow_window_chest",
+      "hexerei:witch_hazel_window_chest"
+    ]
+  }

--- a/src/main/resources/data/forge/tags/blocks/chests.json
+++ b/src/main/resources/data/forge/tags/blocks/chests.json
@@ -1,8 +1,8 @@
 {
-    "replace": false,
-    "values": [
-      "hexerei:mahogany_window_chest",
-      "hexerei:willow_window_chest",
-      "hexerei:witch_hazel_window_chest"
-    ]
-  }
+  "replace": false,
+  "values": [
+    "hexerei:mahogany_chest",
+    "hexerei:willow_chest",
+    "hexerei:witch_hazel_chest"
+  ]
+}

--- a/src/main/resources/data/forge/tags/blocks/chests/wooden.json
+++ b/src/main/resources/data/forge/tags/blocks/chests/wooden.json
@@ -1,0 +1,8 @@
+{
+    "replace": false,
+    "values": [
+      "hexerei:mahogany_window_chest",
+      "hexerei:willow_window_chest",
+      "hexerei:witch_hazel_window_chest"
+    ]
+  }

--- a/src/main/resources/data/forge/tags/blocks/chests/wooden.json
+++ b/src/main/resources/data/forge/tags/blocks/chests/wooden.json
@@ -1,8 +1,8 @@
 {
     "replace": false,
     "values": [
-      "hexerei:mahogany_window_chest",
-      "hexerei:willow_window_chest",
-      "hexerei:witch_hazel_window_chest"
+      "hexerei:mahogany_chest",
+      "hexerei:willow_chest",
+      "hexerei:witch_hazel_chest"
     ]
   }

--- a/src/main/resources/data/forge/tags/items/chests.json
+++ b/src/main/resources/data/forge/tags/items/chests.json
@@ -1,0 +1,8 @@
+{
+    "replace": false,
+    "values": [
+      "hexerei:mahogany_window_chest",
+      "hexerei:willow_window_chest",
+      "hexerei:witch_hazel_window_chest"
+    ]
+  }

--- a/src/main/resources/data/forge/tags/items/chests.json
+++ b/src/main/resources/data/forge/tags/items/chests.json
@@ -1,8 +1,8 @@
 {
     "replace": false,
     "values": [
-      "hexerei:mahogany_window_chest",
-      "hexerei:willow_window_chest",
-      "hexerei:witch_hazel_window_chest"
+      "hexerei:mahogany_chest",
+      "hexerei:willow_chest",
+      "hexerei:witch_hazel_chest"
     ]
   }

--- a/src/main/resources/data/forge/tags/items/chests/wooden.json
+++ b/src/main/resources/data/forge/tags/items/chests/wooden.json
@@ -1,0 +1,8 @@
+{
+    "replace": false,
+    "values": [
+      "hexerei:mahogany_window_chest",
+      "hexerei:willow_window_chest",
+      "hexerei:witch_hazel_window_chest"
+    ]
+  }

--- a/src/main/resources/data/forge/tags/items/chests/wooden.json
+++ b/src/main/resources/data/forge/tags/items/chests/wooden.json
@@ -1,8 +1,8 @@
 {
-    "replace": false,
-    "values": [
-      "hexerei:mahogany_window_chest",
-      "hexerei:willow_window_chest",
-      "hexerei:witch_hazel_window_chest"
-    ]
-  }
+  "replace": false,
+  "values": [
+    "hexerei:mahogany_chest",
+    "hexerei:willow_chest",
+    "hexerei:witch_hazel_chest"
+  ]
+}


### PR DESCRIPTION
Allows them to be used in recipes that use the forge:chests or forge:chests/wooden tags as foung here:

https://github.com/MinecraftForge/MinecraftForge/blob/1.19.x/src/generated/resources/data/forge/tags/blocks/chests/wooden.json

and 

https://github.com/MinecraftForge/MinecraftForge/blob/1.19.x/src/generated/resources/data/forge/tags/items/chests/wooden.json