### PR TITLE
Fix Mixing Cauldron requiring exactly 8 item ingredients in a recipe

### DIFF
--- a/src/main/java/net/joefoxe/hexerei/data/recipes/FluidMixingRecipe.java
+++ b/src/main/java/net/joefoxe/hexerei/data/recipes/FluidMixingRecipe.java
@@ -212,7 +212,7 @@ public class FluidMixingRecipe implements Recipe<SimpleContainer> {
             JsonArray ingredients = GsonHelper.getAsJsonArray(json, "ingredients");
             NonNullList<Ingredient> inputs = NonNullList.withSize(8, Ingredient.EMPTY);
 
-            for (int i = 0; i < inputs.size(); i++) {
+            for (int i = 0; i < ingredients.size(); i++) {
                 inputs.set(i, Ingredient.fromJson(ingredients.get(i)));
             }
 

--- a/src/main/java/net/joefoxe/hexerei/data/recipes/MixingCauldronRecipe.java
+++ b/src/main/java/net/joefoxe/hexerei/data/recipes/MixingCauldronRecipe.java
@@ -94,11 +94,11 @@ public class MixingCauldronRecipe implements Recipe<SimpleContainer> {
         boolean flag = false;
 
         // cycle through each recipe slot
-        for(int j = 0; j < 8; j++) {
+        for(Ingredient recipeItem : recipeItems) {
             //cycle through each slot for each recipe slot
             for (int i = 0; i < 8; i++) {
                 //if the recipe matches a slot
-                if (recipeItems.get(j).test(inv.getItem(i))) {
+                if (recipeItem.test(inv.getItem(i))) {
                     // if the slot is not taken up
                     if (!itemMatchesSlot.get(i)) {
                         //mark the slot as taken up
@@ -214,7 +214,7 @@ public class MixingCauldronRecipe implements Recipe<SimpleContainer> {
             JsonArray ingredients = GsonHelper.getAsJsonArray(json, "ingredients");
             NonNullList<Ingredient> inputs = NonNullList.withSize(8, Ingredient.EMPTY);
 
-            for (int i = 0; i < inputs.size(); i++) {
+            for(int i = 0; i < ingredients.size(); i++) {
                 inputs.set(i, Ingredient.fromJson(ingredients.get(i)));
             }
 


### PR DESCRIPTION
Fixes a bug where JSON recipes would be required to have exactly 8 ingredients in the input, or else the recipe wouldn't load. This fix applies to both item mixing and fluid mixing recipes.