### PR TITLE
Budding Selenite fix

### DIFF
--- a/src/main/java/net/joefoxe/hexerei/block/custom/BuddingSelenite.java
+++ b/src/main/java/net/joefoxe/hexerei/block/custom/BuddingSelenite.java
@@ -4,34 +4,28 @@ import net.joefoxe.hexerei.block.ModBlocks;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.server.level.ServerLevel;
-import net.minecraft.world.level.block.AmethystBlock;
+import net.minecraft.util.RandomSource;
 import net.minecraft.world.level.block.AmethystClusterBlock;
 import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.BuddingAmethystBlock;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.material.Fluids;
-import net.minecraft.world.level.material.PushReaction;
 
-import java.util.Random;
+public class BuddingSelenite extends BuddingAmethystBlock {
+	public static final int GROWTH_CHANCE = 5;
+	private static final Direction[] DIRECTIONS = Direction.values();
 
-public class BuddingSelenite extends AmethystBlock {
-    public static final int GROWTH_CHANCE = 5;
-    private static final Direction[] DIRECTIONS = Direction.values();
+	public BuddingSelenite(Properties pProperties) {
+		super(pProperties);
+	}
 
-    public BuddingSelenite(BlockBehaviour.Properties p_152726_) {
-        super(p_152726_);
-    }
 
-    public PushReaction getPistonPushReaction(BlockState p_152733_) {
-        return PushReaction.DESTROY;
-    }
-
-    public void randomTick(BlockState p_152728_, ServerLevel p_152729_, BlockPos p_152730_, Random p_152731_) {
-        if (p_152731_.nextInt(5) == 0) {
-            Direction direction = DIRECTIONS[p_152731_.nextInt(DIRECTIONS.length)];
-            BlockPos blockpos = p_152730_.relative(direction);
-            BlockState blockstate = p_152729_.getBlockState(blockpos);
+    @Override
+	public void randomTick(BlockState pState, ServerLevel pLevel, BlockPos pPos, RandomSource pRandom) {
+        if (pRandom.nextInt(5) == 0) {
+            Direction direction = DIRECTIONS[pRandom.nextInt(DIRECTIONS.length)];
+            BlockPos blockpos = pPos.relative(direction);
+            BlockState blockstate = pLevel.getBlockState(blockpos);
             Block block = null;
             if (canClusterGrowAtState(blockstate)) {
                 block = ModBlocks.SMALL_SELENITE_BUD.get();
@@ -45,13 +39,11 @@ public class BuddingSelenite extends AmethystBlock {
 
             if (block != null) {
                 BlockState blockstate1 = block.defaultBlockState().setValue(AmethystClusterBlock.FACING, direction).setValue(AmethystClusterBlock.WATERLOGGED, blockstate.getFluidState().getType() == Fluids.WATER);
-                p_152729_.setBlockAndUpdate(blockpos, blockstate1);
+                pLevel.setBlockAndUpdate(blockpos, blockstate1);
             }
 
         }
     }
 
-    public static boolean canClusterGrowAtState(BlockState p_152735_) {
-        return p_152735_.isAir() || p_152735_.is(Blocks.WATER) && p_152735_.getFluidState().getAmount() == 8;
-    }
+
 }


### PR DESCRIPTION
Fixes #74 
Extended the budding amethyst block (cuts down on reusing code this just let us reuse the vanilla canClusterGrowAtState and getPistonPushReaction methods) - This assumes this was the intended behavior

randomTick is called with minecraft.util.RandomSource. Despite this being a re-implementation of java.util.Random, they are not interchangeable.  

changed variable names for readability.