### PR TITLE
Make Mixing Cauldron Bottle Empty/Filling Data Driven

### DIFF
--- a/src/main/java/net/joefoxe/hexerei/block/custom/MixingCauldron.java
+++ b/src/main/java/net/joefoxe/hexerei/block/custom/MixingCauldron.java
@@ -91,6 +91,9 @@ import static net.joefoxe.hexerei.tileentity.renderer.MixingCauldronRenderer.MIN
 @SuppressWarnings("deprecation")
 public class MixingCauldron extends BaseEntityBlock implements ITileEntity<MixingCauldronTile>, DyeableLeatherItem {
 
+    //Moved to constant in case this is changed in the future.
+    public static final int POTION_MB_AMOUNT = 250;
+
     public static final IntegerProperty LEVEL = IntegerProperty.create("level", 0, 3);
     public static final IntegerProperty CRAFT_DELAY = IntegerProperty.create("delay", 0, MixingCauldronTile.craftDelayMax);
     public static final BooleanProperty GUI_RENDER = BooleanProperty.create("gui_render");
@@ -230,7 +233,7 @@ public class MixingCauldron extends BaseEntityBlock implements ITileEntity<Mixin
 //                        ItemStack potionOut = PotionUtils.setPotion(new ItemStack(Items.POTION), PotionFluidHandler.getPotionFromFluidStack(cauldronFluid));
 
             shrinkItem(player, hand, player.getItemInHand(hand), potionOut);
-            cauldronFluid.shrink(250);
+            cauldronFluid.shrink(POTION_MB_AMOUNT);
             cauldronTile.setChanged();
 
             //Effects
@@ -244,15 +247,15 @@ public class MixingCauldron extends BaseEntityBlock implements ITileEntity<Mixin
         }
         //Emptying from potion
         else if (stack.getItem() == Items.POTION || stack.getItem() == Items.LINGERING_POTION || stack.getItem() == Items.SPLASH_POTION) {
-            if ((cauldronFluid.isFluidEqual(PotionFluidHandler.getFluidFromPotionItem(stack)) && cauldronFluid.getAmount() + 250 <= cauldronTile.getTankCapacity(0)) || cauldronFluid.isEmpty()) {
+            if ((cauldronFluid.isFluidEqual(PotionFluidHandler.getFluidFromPotionItem(stack)) && cauldronFluid.getAmount() + POTION_MB_AMOUNT <= cauldronTile.getTankCapacity(0)) || cauldronFluid.isEmpty()) {
                 ItemStack bottle = new ItemStack(Items.GLASS_BOTTLE);
                 player.awardStat(Stats.USE_CAULDRON);
                 shrinkItem(player, hand, player.getItemInHand(hand), bottle);
                 if (cauldronFluid.isEmpty()) {
-                    cauldronTile.fill(new FluidStack(PotionFluidHandler.getFluidFromPotionItem(stack), 250), IFluidHandler.FluidAction.EXECUTE);
+                    cauldronTile.fill(new FluidStack(PotionFluidHandler.getFluidFromPotionItem(stack), POTION_MB_AMOUNT), IFluidHandler.FluidAction.EXECUTE);
                 }
                 else {
-                    cauldronFluid.grow(250);
+                    cauldronFluid.grow(POTION_MB_AMOUNT);
                 }
                 cauldronTile.setChanged();
 

--- a/src/main/java/net/joefoxe/hexerei/block/custom/MixingCauldron.java
+++ b/src/main/java/net/joefoxe/hexerei/block/custom/MixingCauldron.java
@@ -2,6 +2,10 @@ package net.joefoxe.hexerei.block.custom;
 
 import net.joefoxe.hexerei.block.ITileEntity;
 import net.joefoxe.hexerei.container.MixingCauldronContainer;
+import net.joefoxe.hexerei.data.recipes.CauldronEmptyingRecipe;
+import net.joefoxe.hexerei.data.recipes.CauldronFillingRecipe;
+import net.joefoxe.hexerei.data.recipes.ModRecipeTypes;
+import net.joefoxe.hexerei.fluid.FluidIngredient;
 import net.joefoxe.hexerei.fluid.ModFluids;
 import net.joefoxe.hexerei.fluid.PotionFluid;
 import net.joefoxe.hexerei.fluid.PotionFluidHandler;
@@ -31,6 +35,7 @@ import net.minecraft.util.RandomSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.MenuProvider;
+import net.minecraft.world.SimpleContainer;
 import net.minecraft.world.entity.Entity;
 import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
@@ -163,323 +168,105 @@ public class MixingCauldron extends BaseEntityBlock implements ITileEntity<Mixin
 
     @Override
     public InteractionResult use(BlockState state, Level world, BlockPos pos, Player player, InteractionHand hand, BlockHitResult rayTraceResult) {
+        //prevent older checks modifying newer ones, though it probably shouldn't?
         ItemStack stack = player.getItemInHand(hand).copy();
-        Random random = new Random();
-        BlockEntity tileEntity = world.getBlockEntity(pos);
-
-        if (!(tileEntity instanceof MixingCauldronTile cauldronTile))
+        if (!(world.getBlockEntity(pos) instanceof MixingCauldronTile cauldronTile)) {
             return InteractionResult.FAIL;
+        }
+
+        //Crow Flute
         if (stack.is(ModItems.CROW_FLUTE.get()) && stack.getOrCreateTag().getInt("commandMode") == 2) {
             stack.useOn(new UseOnContext(player, hand, rayTraceResult));
             return InteractionResult.SUCCESS;
         }
+
+        //Blood sigil
         if (stack.is(HexereiTags.Items.SIGILS)) {
 
-            MixingCauldronTile mixingCauldronTile = (MixingCauldronTile) tileEntity;
-            if (mixingCauldronTile.getItemStackInSlot(9).isEmpty()) {
+            if (cauldronTile.getItemStackInSlot(9).isEmpty()) {
                 stack.setCount(1);
-                mixingCauldronTile.setItem(9, stack);
+                cauldronTile.setItem(9, stack);
                 player.getItemInHand(hand).shrink(1);
-                tileEntity.setChanged();
+                cauldronTile.setChanged();
                 return InteractionResult.SUCCESS;
-            } else if (!mixingCauldronTile.getItemStackInSlot(9).is(stack.getItem())) {
-                player.inventory.placeItemBackInInventory(mixingCauldronTile.getItemStackInSlot(9));
+            } else if (!cauldronTile.getItemStackInSlot(9).is(stack.getItem())) {
+                player.inventory.placeItemBackInInventory(cauldronTile.getItemStackInSlot(9));
                 stack.setCount(1);
-                mixingCauldronTile.setItem(9, stack);
+                cauldronTile.setItem(9, stack);
                 player.getItemInHand(hand).shrink(1);
-                tileEntity.setChanged();
+                cauldronTile.setChanged();
                 return InteractionResult.SUCCESS;
             }
 
         }
-        if (stack.getItem() == Items.GLASS_BOTTLE) {
-            if (cauldronTile.getFluidStack().getAmount() >= 250) {
-                if (cauldronTile.getFluidStack().isFluidEqual(new FluidStack(Fluids.WATER, 1))) {
-                    ItemStack itemstack4 = PotionUtils.setPotion(new ItemStack(Items.POTION), Potions.WATER);
-                    player.awardStat(Stats.USE_CAULDRON);
-                    if (!player.isCreative()) {
-                        player.getItemInHand(hand).shrink(1);
-                        if (player.getItemInHand(hand).isEmpty()) {
-                            player.setItemInHand(hand, itemstack4);
-                        } else if (!player.getInventory().add(itemstack4)) {
-                            player.drop(itemstack4, false);
-                        }
-                    }
-                    cauldronTile.getFluidStack().shrink(250);
-                    if (!world.isClientSide)
-                        HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> world.getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
-                    if (world != null)
-                        world.playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_FILL, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
-                    tileEntity.setChanged();
-                    return InteractionResult.SUCCESS;
-                } else if (cauldronTile.getFluidStack().isFluidEqual(new FluidStack(Fluids.LAVA, 1))) {
-                    ItemStack itemstack4 = new ItemStack(ModItems.LAVA_BOTTLE.get());
-                    player.awardStat(Stats.USE_CAULDRON);
-                    if (!player.isCreative()) {
-                        player.getItemInHand(hand).shrink(1);
-                        if (player.getItemInHand(hand).isEmpty()) {
-                            player.setItemInHand(hand, itemstack4);
-                        } else if (!player.getInventory().add(itemstack4)) {
-                            player.drop(itemstack4, false);
-                        }
-                    }
-                    cauldronTile.getFluidStack().shrink(250);
-                    if (!world.isClientSide)
-                        HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> world.getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
-                    if (world != null)
-                        world.playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_FILL, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
-                    tileEntity.setChanged();
-                    return InteractionResult.SUCCESS;
-                } else if (cauldronTile.getFluidStack().isFluidEqual(new FluidStack(ModFluids.QUICKSILVER_FLUID.get(), 1))) {
-                    ItemStack itemstack4 = new ItemStack(ModItems.QUICKSILVER_BOTTLE.get());
-                    player.awardStat(Stats.USE_CAULDRON);
-                    if (!player.isCreative()) {
-                        player.getItemInHand(hand).shrink(1);
-                        if (player.getItemInHand(hand).isEmpty()) {
-                            player.setItemInHand(hand, itemstack4);
-                        } else if (!player.getInventory().add(itemstack4)) {
-                            player.drop(itemstack4, false);
-                        }
-                    }
-                    cauldronTile.getFluidStack().shrink(250);
-                    if (!world.isClientSide)
-                        HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> world.getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
-                    if (world != null)
-                        world.playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_FILL, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
-                    tileEntity.setChanged();
-                    return InteractionResult.SUCCESS;
-                } else if (cauldronTile.getFluidStack().isFluidEqual(new FluidStack(ModFluids.TALLOW_FLUID.get(), 1))) {
-                    ItemStack itemstack4 = new ItemStack(ModItems.TALLOW_BOTTLE.get());
-                    player.awardStat(Stats.USE_CAULDRON);
-                    if (!player.isCreative()) {
-                        player.getItemInHand(hand).shrink(1);
-                        if (player.getItemInHand(hand).isEmpty()) {
-                            player.setItemInHand(hand, itemstack4);
-                        } else if (!player.getInventory().add(itemstack4)) {
-                            player.drop(itemstack4, false);
-                        }
-                    }
-                    cauldronTile.getFluidStack().shrink(250);
-                    if (!world.isClientSide)
-                        HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> world.getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
-                    if (world != null)
-                        world.playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_FILL, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
-                    tileEntity.setChanged();
-                    return InteractionResult.SUCCESS;
-                } else if (cauldronTile.getFluidStack().isFluidEqual(new FluidStack(ModFluids.BLOOD_FLUID.get(), 1))) {
-                    ItemStack itemstack4 = new ItemStack(ModItems.BLOOD_BOTTLE.get());
-                    player.awardStat(Stats.USE_CAULDRON);
-                    if (!player.isCreative()) {
-                        player.getItemInHand(hand).shrink(1);
-                        if (player.getItemInHand(hand).isEmpty()) {
-                            player.setItemInHand(hand, itemstack4);
-                        } else if (!player.getInventory().add(itemstack4)) {
-                            player.drop(itemstack4, false);
-                        }
-                    }
-                    cauldronTile.getFluidStack().shrink(250);
-                    if (!world.isClientSide)
-                        HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> world.getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
-                    if (world != null)
-                        world.playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_FILL, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
-                    tileEntity.setChanged();
-                    return InteractionResult.SUCCESS;
-                } else if (cauldronTile.getFluidStack().getFluid() instanceof PotionFluid) {
-                    ItemStack itemstack4 = PotionFluidHandler.fillBottle(cauldronTile.getFluidStack());
-//                        ItemStack itemstack4 = PotionUtils.setPotion(new ItemStack(Items.POTION), PotionFluidHandler.getPotionFromFluidStack(cauldronTile.getFluidStack()));
-                    player.awardStat(Stats.USE_CAULDRON);
-                    if (!player.isCreative()) {
-                        player.getItemInHand(hand).shrink(1);
-                        if (player.getItemInHand(hand).isEmpty()) {
-                            player.setItemInHand(hand, itemstack4);
-                        } else if (!player.getInventory().add(itemstack4)) {
-                            player.drop(itemstack4, false);
-                        }
-                    }
-                    cauldronTile.getFluidStack().shrink(250);
-                    if (!world.isClientSide)
-                        HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> world.getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
-                    if (world != null)
-                        world.playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_FILL, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
-                    tileEntity.setChanged();
-                    return InteractionResult.SUCCESS;
-                }
-            }
-        } else if (stack.getItem() == Items.POTION || stack.getItem() == Items.LINGERING_POTION || stack.getItem() == Items.SPLASH_POTION) {
-            if (PotionUtils.getPotion(stack) == Potions.WATER) {
-                if (cauldronTile.getFluidStack().isFluidEqual(new FluidStack(Fluids.WATER, 1)) || cauldronTile.getFluidStack().isEmpty()) {
-                    ItemStack itemstack4 = new ItemStack(Items.GLASS_BOTTLE);
-                    player.awardStat(Stats.USE_CAULDRON);
-                    if (!player.isCreative()) {
-                        player.getItemInHand(hand).shrink(1);
-                        if (player.getItemInHand(hand).isEmpty()) {
-                            player.setItemInHand(hand, itemstack4);
-                        } else if (!player.getInventory().add(itemstack4)) {
-                            player.drop(itemstack4, false);
-                        }
-                    }
-                    if (cauldronTile.getFluidStack().isEmpty())
-                        cauldronTile.fill(new FluidStack(Fluids.WATER, 250), IFluidHandler.FluidAction.EXECUTE);
-                    else
-                        cauldronTile.getFluidStack().grow(250);
-                    if (cauldronTile.getFluidStack().getAmount() > cauldronTile.getTankCapacity(1))
-                        cauldronTile.getFluidStack().setAmount(cauldronTile.getTankCapacity(1));
-                    if (!tileEntity.getLevel().isClientSide)
-                        HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> tileEntity.getLevel().getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
-                    if (tileEntity.getLevel() != null)
-                        tileEntity.getLevel().playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
-                    tileEntity.setChanged();
-                    return InteractionResult.SUCCESS;
-                }
 
-            } else {
+        FluidStack cauldronFluid = cauldronTile.getFluidStack();
 
-                if (cauldronTile.getFluidStack().isFluidEqual(PotionFluidHandler.getFluidFromPotionItem(stack)) || cauldronTile.getFluidStack().isEmpty()) {
-                    ItemStack itemstack4 = new ItemStack(Items.GLASS_BOTTLE);
-                    player.awardStat(Stats.USE_CAULDRON);
-                    if (!player.isCreative()) {
-                        player.getItemInHand(hand).shrink(1);
-                        if (player.getItemInHand(hand).isEmpty()) {
-                            player.setItemInHand(hand, itemstack4);
-                        } else if (!player.getInventory().add(itemstack4)) {
-                            player.drop(itemstack4, false);
-                        }
-                    }
-                    if (cauldronTile.getFluidStack().isEmpty())
-                        cauldronTile.fill(new FluidStack(PotionFluidHandler.getFluidFromPotionItem(stack), 250), IFluidHandler.FluidAction.EXECUTE);
-                    else
-                        cauldronTile.getFluidStack().grow(250);
-                    if (cauldronTile.getFluidStack().getAmount() > cauldronTile.getTankCapacity(1))
-                        cauldronTile.getFluidStack().setAmount(cauldronTile.getTankCapacity(1));
-                    if (!tileEntity.getLevel().isClientSide)
-                        HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> tileEntity.getLevel().getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
-                    if (tileEntity.getLevel() != null)
-                        tileEntity.getLevel().playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
-                    tileEntity.setChanged();
-                    return InteractionResult.SUCCESS;
-                }
+        //Filling from recipe
+        Optional<CauldronFillingRecipe> fillingOptional = world.getRecipeManager().getRecipeFor(ModRecipeTypes.CAULDRON_FILLING_TYPE.get(), new SimpleContainer(stack), world);
+        if(fillingOptional.isPresent()) {
+            CauldronFillingRecipe recipe = fillingOptional.get();
+            ItemStack output = recipe.getResultItem(world.registryAccess());
+            FluidStack fluidOut = recipe.getResultingFluid();
+            if(cauldronFluid.getFluid().isSame(Fluids.EMPTY) || (fluidOut.getFluid().isSame(cauldronFluid.getFluid()) && cauldronFluid.getAmount() + fluidOut.getAmount() <= cauldronTile.getTankCapacity(0))) {
+                return fillFromItem(cauldronTile, world, player, hand, player.getItemInHand(hand), output, fluidOut);
+            }
+        }
 
+        //Emptying from recipe
+        Optional<CauldronEmptyingRecipe> emptyingOptional = world.getRecipeManager().getRecipeFor(ModRecipeTypes.CAULDRON_EMPTYING_TYPE.get(), new CauldronEmptyingRecipe.Wrapper(stack, cauldronFluid), world);
+        if(emptyingOptional.isPresent()) {
+            CauldronEmptyingRecipe recipe = emptyingOptional.get();
+            ItemStack output = recipe.getResultItem(world.registryAccess());
+            FluidIngredient fluidIn = recipe.getFluid();
+            if(cauldronFluid.getAmount() - fluidIn.getRequiredAmount() >= 0) {
+                return emptyToItem(cauldronTile, world, player, hand, player.getItemInHand(hand), new FluidStack(cauldronFluid.getFluid(), fluidIn.getRequiredAmount()), output);
             }
-        } else if (stack.getItem() == ModItems.LAVA_BOTTLE.get()) {
-            if (cauldronTile.getFluidStack().isFluidEqual(new FluidStack(Fluids.LAVA, 1)) || cauldronTile.getFluidStack().isEmpty()) {
-                ItemStack itemstack4 = new ItemStack(Items.GLASS_BOTTLE);
-                player.awardStat(Stats.USE_CAULDRON);
-                if (!player.isCreative()) {
-                    player.getItemInHand(hand).shrink(1);
-                    if (player.getItemInHand(hand).isEmpty()) {
-                        player.setItemInHand(hand, itemstack4);
-                    } else if (!player.getInventory().add(itemstack4)) {
-                        player.drop(itemstack4, false);
-                    }
-                }
-                if (cauldronTile.getFluidStack().isEmpty())
-                    cauldronTile.fill(new FluidStack(Fluids.LAVA, 250), IFluidHandler.FluidAction.EXECUTE);
-                else
-                    cauldronTile.getFluidStack().grow(250);
-                if (cauldronTile.getFluidStack().getAmount() > cauldronTile.getTankCapacity(1))
-                    cauldronTile.getFluidStack().setAmount(cauldronTile.getTankCapacity(1));
-                if (cauldronTile.getFluidStack().getAmount() % 10 == 1)
-                    cauldronTile.getFluidStack().shrink(1);
-                if (cauldronTile.getFluidStack().getAmount() % 10 == 9)
-                    cauldronTile.getFluidStack().grow(1);
-                if (!tileEntity.getLevel().isClientSide)
-                    HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> tileEntity.getLevel().getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
-                if (tileEntity.getLevel() != null)
-                    tileEntity.getLevel().playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
-                tileEntity.setChanged();
-                return InteractionResult.SUCCESS;
-            }
-        } else if (stack.getItem() == ModItems.QUICKSILVER_BOTTLE.get()) {
-            if (cauldronTile.getFluidStack().isFluidEqual(new FluidStack(ModFluids.QUICKSILVER_FLUID.get(), 1)) || cauldronTile.getFluidStack().isEmpty()) {
-                ItemStack itemstack4 = new ItemStack(Items.GLASS_BOTTLE);
-                player.awardStat(Stats.USE_CAULDRON);
-                if (!player.isCreative()) {
-                    player.getItemInHand(hand).shrink(1);
-                    if (player.getItemInHand(hand).isEmpty()) {
-                        player.setItemInHand(hand, itemstack4);
-                    } else if (!player.getInventory().add(itemstack4)) {
-                        player.drop(itemstack4, false);
-                    }
-                }
-                if (cauldronTile.getFluidStack().isEmpty())
-                    cauldronTile.fill(new FluidStack(ModFluids.QUICKSILVER_FLUID.get(), 250), IFluidHandler.FluidAction.EXECUTE);
-                else
-                    cauldronTile.getFluidStack().grow(250);
-                if (cauldronTile.getFluidStack().getAmount() > cauldronTile.getTankCapacity(1))
-                    cauldronTile.getFluidStack().setAmount(cauldronTile.getTankCapacity(1));
-                if (cauldronTile.getFluidStack().getAmount() % 10 == 1)
-                    cauldronTile.getFluidStack().shrink(1);
-                if (cauldronTile.getFluidStack().getAmount() % 10 == 9)
-                    cauldronTile.getFluidStack().grow(1);
-                if (!tileEntity.getLevel().isClientSide)
-                    HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> tileEntity.getLevel().getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
-                if (tileEntity.getLevel() != null)
-                    tileEntity.getLevel().playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
-                tileEntity.setChanged();
-                return InteractionResult.SUCCESS;
-            }
-        } else if (stack.getItem() == ModItems.TALLOW_BOTTLE.get()) {
-            if (cauldronTile.getFluidStack().isFluidEqual(new FluidStack(ModFluids.TALLOW_FLUID.get(), 1)) || cauldronTile.getFluidStack().isEmpty()) {
-                ItemStack itemstack4 = new ItemStack(Items.GLASS_BOTTLE);
-                player.awardStat(Stats.USE_CAULDRON);
-                if (!player.isCreative()) {
-                    player.getItemInHand(hand).shrink(1);
-                    if (player.getItemInHand(hand).isEmpty()) {
-                        player.setItemInHand(hand, itemstack4);
-                    } else if (!player.getInventory().add(itemstack4)) {
-                        player.drop(itemstack4, false);
-                    }
-                }
-                if (cauldronTile.getFluidStack().isEmpty())
-                    cauldronTile.fill(new FluidStack(ModFluids.TALLOW_FLUID.get(), 250), IFluidHandler.FluidAction.EXECUTE);
-                else
-                    cauldronTile.getFluidStack().grow(250);
-                if (cauldronTile.getFluidStack().getAmount() > cauldronTile.getTankCapacity(1))
-                    cauldronTile.getFluidStack().setAmount(cauldronTile.getTankCapacity(1));
-                if (cauldronTile.getFluidStack().getAmount() % 10 == 1)
-                    cauldronTile.getFluidStack().shrink(1);
-                if (cauldronTile.getFluidStack().getAmount() % 10 == 9)
-                    cauldronTile.getFluidStack().grow(1);
-                if (!tileEntity.getLevel().isClientSide)
-                    HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> tileEntity.getLevel().getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
+        }
 
-                if (tileEntity.getLevel() != null)
-                    tileEntity.getLevel().playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
-                tileEntity.setChanged();
-                return InteractionResult.SUCCESS;
+        //Filling from potion
+        if (cauldronFluid.getFluid() instanceof PotionFluid && stack.getItem() == Items.GLASS_BOTTLE) {
+            ItemStack potionOut = PotionFluidHandler.fillBottle(cauldronFluid);
+//                        ItemStack potionOut = PotionUtils.setPotion(new ItemStack(Items.POTION), PotionFluidHandler.getPotionFromFluidStack(cauldronFluid));
+
+            shrinkItem(player, hand, player.getItemInHand(hand), potionOut);
+            cauldronFluid.shrink(250);
+            cauldronTile.setChanged();
+
+            //Effects
+            Random random = new Random();
+            if (!world.isClientSide) {
+                HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> world.getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
             }
-        } else if (stack.getItem() == ModItems.BLOOD_BOTTLE.get()) {
-            if (cauldronTile.getFluidStack().isFluidEqual(new FluidStack(ModFluids.BLOOD_FLUID.get(), 1)) || cauldronTile.getFluidStack().isEmpty()) {
-                ItemStack itemstack4 = new ItemStack(Items.GLASS_BOTTLE);
+
+            world.playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_FILL, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
+            return InteractionResult.SUCCESS;
+        }
+        //Emptying from potion
+        else if (stack.getItem() == Items.POTION || stack.getItem() == Items.LINGERING_POTION || stack.getItem() == Items.SPLASH_POTION) {
+            if ((cauldronFluid.isFluidEqual(PotionFluidHandler.getFluidFromPotionItem(stack)) && cauldronFluid.getAmount() + 250 <= cauldronTile.getTankCapacity(0)) || cauldronFluid.isEmpty()) {
+                ItemStack bottle = new ItemStack(Items.GLASS_BOTTLE);
                 player.awardStat(Stats.USE_CAULDRON);
-                if (!player.isCreative()) {
-                    player.getItemInHand(hand).shrink(1);
-                    if (player.getItemInHand(hand).isEmpty()) {
-                        player.setItemInHand(hand, itemstack4);
-                    } else if (!player.getInventory().add(itemstack4)) {
-                        player.drop(itemstack4, false);
-                    }
+                shrinkItem(player, hand, player.getItemInHand(hand), bottle);
+                if (cauldronFluid.isEmpty()) {
+                    cauldronTile.fill(new FluidStack(PotionFluidHandler.getFluidFromPotionItem(stack), 250), IFluidHandler.FluidAction.EXECUTE);
                 }
-                if (cauldronTile.getFluidStack().isEmpty())
-                    cauldronTile.fill(new FluidStack(ModFluids.BLOOD_FLUID.get(), 250), IFluidHandler.FluidAction.EXECUTE);
-                else
-                    cauldronTile.getFluidStack().grow(250);
-                if (cauldronTile.getFluidStack().getAmount() > cauldronTile.getTankCapacity(1))
-                    cauldronTile.getFluidStack().setAmount(cauldronTile.getTankCapacity(1));
-                if (cauldronTile.getFluidStack().getAmount() % 10 == 1)
-                    cauldronTile.getFluidStack().shrink(1);
-                if (cauldronTile.getFluidStack().getAmount() % 10 == 9)
-                    cauldronTile.getFluidStack().grow(1);
-                if (!tileEntity.getLevel().isClientSide)
-                    HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> tileEntity.getLevel().getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
-                if (tileEntity.getLevel() != null)
-                    tileEntity.getLevel().playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
-                tileEntity.setChanged();
+                else {
+                    cauldronFluid.grow(250);
+                }
+                cauldronTile.setChanged();
+
+                //Effects
+                Random random = new Random();
+                if (!world.isClientSide) {
+                    HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> world.getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
+                }
+                world.playSound(null, cauldronTile.getPos().getX() + 0.5f, cauldronTile.getPos().getY() + 0.5f, cauldronTile.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
                 return InteractionResult.SUCCESS;
             }
         }
 
-
+        //Item fluid tanks (buckets)
         ItemStack fillStack = stack.copy();
         fillStack.setCount(1);
         LazyOptional<IFluidHandlerItem> fluidHandlerOptional = fillStack.getCapability(ForgeCapabilities.FLUID_HANDLER_ITEM);
@@ -499,7 +286,7 @@ public class MixingCauldron extends BaseEntityBlock implements ITileEntity<Mixin
                     }
                 }
                 if (!world.isClientSide)
-                    HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> tileEntity.getLevel().getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
+                    HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> world.getChunkAt(cauldronTile.getPos())), new EmitParticlesPacket(cauldronTile.getPos(), 3, false));
 
 
                 return InteractionResult.sidedSuccess(world.isClientSide);
@@ -512,12 +299,63 @@ public class MixingCauldron extends BaseEntityBlock implements ITileEntity<Mixin
 
             MenuProvider containerProvider = createContainerProvider(world, pos);
 
-            NetworkHooks.openScreen(((ServerPlayer) player), containerProvider, tileEntity.getBlockPos());
+            NetworkHooks.openScreen(((ServerPlayer) player), containerProvider, cauldronTile.getBlockPos());
 
         }
 
         return InteractionResult.SUCCESS;
     }
+
+    private InteractionResult fillFromItem(MixingCauldronTile mixingCauldron, Level level, Player player, InteractionHand hand, ItemStack stackIn, ItemStack stackOut, FluidStack fluid) {
+        player.awardStat(Stats.USE_CAULDRON);
+        shrinkItem(player, hand, stackIn, stackOut);
+        if(mixingCauldron.getFluidStack().isEmpty()) {
+            mixingCauldron.fill(fluid, IFluidHandler.FluidAction.EXECUTE);
+        }
+        else {
+            mixingCauldron.getFluidStack().grow(fluid.getAmount());
+        }
+        mixingCauldron.normalizeTank();
+
+        //Effects
+        Random random = new Random();
+        if (!level.isClientSide) {
+            HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> level.getChunkAt(mixingCauldron.getPos())), new EmitParticlesPacket(mixingCauldron.getPos(), 3, false));
+        }
+        level.playSound(null, mixingCauldron.getPos().getX() + 0.5f, mixingCauldron.getPos().getY() + 0.5f, mixingCauldron.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_EMPTY, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
+        mixingCauldron.setChanged();
+        return InteractionResult.SUCCESS;
+    }
+
+    private InteractionResult emptyToItem(MixingCauldronTile mixingCauldron, Level level, Player player, InteractionHand hand, ItemStack stackIn, FluidStack fluid, ItemStack stackOut) {
+        player.awardStat(Stats.USE_CAULDRON);
+        shrinkItem(player, hand, stackIn, stackOut);
+        mixingCauldron.getFluidStack().shrink(fluid.getAmount());
+        mixingCauldron.normalizeTank();
+        mixingCauldron.setChanged();
+
+        //Effects
+        Random random = new Random();
+        if (!level.isClientSide) {
+            HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> level.getChunkAt(mixingCauldron.getPos())), new EmitParticlesPacket(mixingCauldron.getPos(), 3, false));
+        }
+        level.playSound(null, mixingCauldron.getPos().getX() + 0.5f, mixingCauldron.getPos().getY() + 0.5f, mixingCauldron.getPos().getZ() + 0.5f, SoundEvents.BOTTLE_FILL, SoundSource.BLOCKS, 1.0F, 0.8F + 0.4F * random.nextFloat());
+
+        return InteractionResult.SUCCESS;
+    }
+
+    private void shrinkItem(Player player, InteractionHand hand, ItemStack stackIn, ItemStack stackOut) {
+        if(!player.isCreative()) {
+            stackIn.shrink(1);
+            if(stackIn.isEmpty()) {
+                player.setItemInHand(hand, stackOut);
+            }
+            else {
+                player.getInventory().placeItemBackInInventory(stackOut);
+            }
+        }
+    }
+
 
     public MixingCauldron(Properties properties) {
 

--- a/src/main/java/net/joefoxe/hexerei/data/recipes/CauldronEmptyingRecipe.java
+++ b/src/main/java/net/joefoxe/hexerei/data/recipes/CauldronEmptyingRecipe.java
@@ -1,0 +1,122 @@
+package net.joefoxe.hexerei.data.recipes;
+
+import com.google.gson.JsonObject;
+import net.joefoxe.hexerei.fluid.FluidIngredient;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.*;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import net.minecraftforge.items.ItemStackHandler;
+import net.minecraftforge.items.wrapper.RecipeWrapper;
+import org.jetbrains.annotations.Nullable;
+
+import static net.joefoxe.hexerei.data.recipes.MixingCauldronRecipe.Serializer.deserializeFluidStack;
+
+public class CauldronEmptyingRecipe implements Recipe<CauldronEmptyingRecipe.Wrapper> {
+
+    private final ResourceLocation id;
+    private final Ingredient input;
+    private final FluidIngredient fluid;
+    private final ItemStack output;
+
+    public CauldronEmptyingRecipe(ResourceLocation id, Ingredient input, FluidIngredient fluid, ItemStack output) {
+        this.id = id;
+        this.input = input;
+        this.fluid = fluid;
+        this.output = output;
+    }
+
+    @Override
+    public boolean isSpecial() {
+        return true;
+    }
+
+    @Override
+    public boolean matches(Wrapper pContainer, Level pLevel) {
+        return input.test(pContainer.getInput()) && fluid.test(pContainer.getFluid());
+    }
+
+    @Override
+    public ItemStack assemble(Wrapper pContainer, RegistryAccess pRegistryAccess) {
+        return getResultItem(pRegistryAccess);
+    }
+
+    @Override
+    public boolean canCraftInDimensions(int pWidth, int pHeight) {
+        return true;
+    }
+
+    public FluidIngredient getFluid() {
+        return fluid;
+    }
+
+    @Override
+    public ItemStack getResultItem(RegistryAccess pRegistryAccess) {
+        return output.copy();
+    }
+
+    @Override
+    public ResourceLocation getId() {
+        return id;
+    }
+
+    @Override
+    public RecipeSerializer<?> getSerializer() {
+        return ModRecipeTypes.CAULDRON_EMPTYING_SERIALIZER.get();
+    }
+
+    @Override
+    public RecipeType<?> getType() {
+        return ModRecipeTypes.CAULDRON_EMPTYING_TYPE.get();
+    }
+
+    public static class Wrapper extends RecipeWrapper {
+
+        private final FluidStack fluid;
+        public Wrapper(ItemStack stack, FluidStack fluid) {
+            super(new ItemStackHandler(1));
+            this.fluid = fluid;
+            setItem(0, stack);
+        }
+
+        public ItemStack getInput() {
+            return this.getItem(0);
+        }
+        public FluidStack getFluid() {
+            return fluid;
+        }
+    }
+
+    public static class Serializer implements RecipeSerializer<CauldronEmptyingRecipe> {
+
+        @Override
+        public CauldronEmptyingRecipe fromJson(ResourceLocation pRecipeId, JsonObject pSerializedRecipe) {
+            Ingredient input = Ingredient.fromJson(pSerializedRecipe.get("input"));
+            FluidStack fluid = deserializeFluidStack(GsonHelper.getAsJsonObject(pSerializedRecipe, "fluid"));
+            ItemStack output = ShapedRecipe.itemStackFromJson(GsonHelper.getAsJsonObject(pSerializedRecipe, "output"));
+
+            return new CauldronEmptyingRecipe(pRecipeId, input, FluidIngredient.fromFluidStack(fluid), output);
+        }
+
+        @Override
+        public @Nullable CauldronEmptyingRecipe fromNetwork(ResourceLocation pRecipeId, FriendlyByteBuf buf) {
+            Ingredient input = Ingredient.fromNetwork(buf);
+            FluidStack fluid = FluidStack.readFromPacket(buf);
+            ItemStack output = buf.readItem();
+            return new CauldronEmptyingRecipe(pRecipeId, input, FluidIngredient.fromFluidStack(fluid), output);
+        }
+
+        @Override
+        public void toNetwork(FriendlyByteBuf buf, CauldronEmptyingRecipe recipe) {
+            recipe.input.toNetwork(buf);
+            recipe.fluid.write(buf);
+            buf.writeItem(recipe.output);
+        }
+    }
+}

--- a/src/main/java/net/joefoxe/hexerei/data/recipes/CauldronEmptyingRecipe.java
+++ b/src/main/java/net/joefoxe/hexerei/data/recipes/CauldronEmptyingRecipe.java
@@ -52,12 +52,20 @@ public class CauldronEmptyingRecipe implements Recipe<CauldronEmptyingRecipe.Wra
         return true;
     }
 
+    public Ingredient getInput() {
+        return input;
+    }
+
     public FluidIngredient getFluid() {
         return fluid;
     }
 
     @Override
     public ItemStack getResultItem(RegistryAccess pRegistryAccess) {
+        return output.copy();
+    }
+
+    public ItemStack getResultItem() {
         return output.copy();
     }
 

--- a/src/main/java/net/joefoxe/hexerei/data/recipes/CauldronFillingRecipe.java
+++ b/src/main/java/net/joefoxe/hexerei/data/recipes/CauldronFillingRecipe.java
@@ -1,0 +1,101 @@
+package net.joefoxe.hexerei.data.recipes;
+
+import com.google.gson.JsonObject;
+import net.minecraft.core.RegistryAccess;
+import net.minecraft.network.FriendlyByteBuf;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.util.GsonHelper;
+import net.minecraft.world.SimpleContainer;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.*;
+import net.minecraft.world.level.Level;
+import net.minecraftforge.fluids.FluidStack;
+import org.jetbrains.annotations.Nullable;
+
+import static net.joefoxe.hexerei.data.recipes.MixingCauldronRecipe.Serializer.deserializeFluidStack;
+
+public class CauldronFillingRecipe implements Recipe<SimpleContainer> {
+
+    private final ResourceLocation id;
+    private final Ingredient input;
+    private final ItemStack output;
+    private final FluidStack fluid;
+
+    public CauldronFillingRecipe(ResourceLocation id, Ingredient input, ItemStack output, FluidStack fluid) {
+        this.id = id;
+        this.input = input;
+        this.output = output;
+        this.fluid = fluid;
+    }
+
+    @Override
+    public boolean isSpecial() {
+        return true;
+    }
+
+    @Override
+    public boolean matches(SimpleContainer pContainer, Level pLevel) {
+        return input.test(pContainer.getItem(0));
+    }
+
+    @Override
+    public ItemStack assemble(SimpleContainer pContainer, RegistryAccess pRegistryAccess) {
+        return getResultItem(pRegistryAccess);
+    }
+
+    @Override
+    public boolean canCraftInDimensions(int pWidth, int pHeight) {
+        return true;
+    }
+
+    @Override
+    public ItemStack getResultItem(RegistryAccess pRegistryAccess) {
+        return output.copy();
+    }
+
+    public FluidStack getResultingFluid() {
+        return fluid.copy();
+    }
+
+    @Override
+    public ResourceLocation getId() {
+        return id;
+    }
+
+    @Override
+    public RecipeSerializer<?> getSerializer() {
+        return ModRecipeTypes.CAULDRON_FILLING_SERIALIZER.get();
+    }
+
+    @Override
+    public RecipeType<?> getType() {
+        return ModRecipeTypes.CAULDRON_FILLING_TYPE.get();
+    }
+
+    public static class Serializer implements RecipeSerializer<CauldronFillingRecipe> {
+
+        @Override
+        public CauldronFillingRecipe fromJson(ResourceLocation pRecipeId, JsonObject pSerializedRecipe) {
+            Ingredient input = Ingredient.fromJson(pSerializedRecipe.get("input"));
+            ItemStack result = ShapedRecipe.itemStackFromJson(GsonHelper.getAsJsonObject(pSerializedRecipe, "output"));
+            FluidStack fluid = deserializeFluidStack(GsonHelper.getAsJsonObject(pSerializedRecipe, "fluid"));
+
+            return new CauldronFillingRecipe(pRecipeId, input, result, fluid);
+        }
+
+        @Override
+        public @Nullable CauldronFillingRecipe fromNetwork(ResourceLocation pRecipeId, FriendlyByteBuf buf) {
+            Ingredient input = Ingredient.fromNetwork(buf);
+            ItemStack result = buf.readItem();
+            FluidStack fluid = FluidStack.readFromPacket(buf);
+            return new CauldronFillingRecipe(pRecipeId, input, result, fluid);
+        }
+
+        @Override
+        public void toNetwork(FriendlyByteBuf buf, CauldronFillingRecipe recipe) {
+            recipe.input.toNetwork(buf);
+            buf.writeItem(recipe.output);
+            recipe.fluid.writeToPacket(buf);
+        }
+    }
+}

--- a/src/main/java/net/joefoxe/hexerei/data/recipes/MixingCauldronRecipe.java
+++ b/src/main/java/net/joefoxe/hexerei/data/recipes/MixingCauldronRecipe.java
@@ -259,8 +259,11 @@ public class MixingCauldronRecipe implements Recipe<SimpleContainer> {
             Fluid fluid = ForgeRegistries.FLUIDS.getValue(id);
             if (fluid == null)
                 throw new JsonSyntaxException("Unknown fluid '" + id + "'");
-            FluidStack stack = new FluidStack(fluid, 1);
-
+            int amount = 1;
+            if(json.has("amount")) {
+                amount = GsonHelper.getAsInt(json, "amount");
+            }
+            FluidStack stack = new FluidStack(fluid, amount);
             if (!json.has("nbt"))
                 return stack;
 

--- a/src/main/java/net/joefoxe/hexerei/data/recipes/ModRecipeTypes.java
+++ b/src/main/java/net/joefoxe/hexerei/data/recipes/ModRecipeTypes.java
@@ -99,6 +99,11 @@ public class ModRecipeTypes {
 
     public static final RegistryObject<RecipeType<WoodcutterRecipe>> WOODCUTTING_TYPE = RECIPE_TYPES.register("woodcutting", ModRecipeType::new);
 
+    public static final RegistryObject<RecipeType<CauldronFillingRecipe>> CAULDRON_FILLING_TYPE = RECIPE_TYPES.register("cauldron_filling", ModRecipeType::new);
+    public static final RegistryObject<RecipeSerializer<CauldronFillingRecipe>> CAULDRON_FILLING_SERIALIZER = RECIPE_SERIALIZERS.register("cauldron_filling", CauldronFillingRecipe.Serializer::new);
+
+    public static final RegistryObject<RecipeType<CauldronEmptyingRecipe>> CAULDRON_EMPTYING_TYPE = RECIPE_TYPES.register("cauldron_emptying", ModRecipeType::new);
+    public static final RegistryObject<RecipeSerializer<CauldronEmptyingRecipe>> CAULDRON_EMPTYING_SERIALIZER = RECIPE_SERIALIZERS.register("cauldron_emptying", CauldronEmptyingRecipe.Serializer::new);
 
     private static class ModRecipeType<T extends Recipe<?>> implements RecipeType<T> {
         @Override

--- a/src/main/java/net/joefoxe/hexerei/integration/jei/BottlingRecipeCategory.java
+++ b/src/main/java/net/joefoxe/hexerei/integration/jei/BottlingRecipeCategory.java
@@ -5,6 +5,7 @@ import com.mojang.blaze3d.platform.Lighting;
 import com.mojang.blaze3d.systems.RenderSystem;
 import com.mojang.blaze3d.vertex.PoseStack;
 import com.mojang.math.Axis;
+import mezz.jei.api.forge.ForgeTypes;
 import mezz.jei.api.gui.builder.IRecipeLayoutBuilder;
 import mezz.jei.api.gui.drawable.IDrawable;
 import mezz.jei.api.gui.ingredient.IRecipeSlotTooltipCallback;
@@ -18,6 +19,7 @@ import mezz.jei.api.recipe.category.IRecipeCategory;
 import net.joefoxe.hexerei.Hexerei;
 import net.joefoxe.hexerei.block.ModBlocks;
 import net.joefoxe.hexerei.block.custom.MixingCauldron;
+import net.joefoxe.hexerei.data.recipes.CauldronEmptyingRecipe;
 import net.joefoxe.hexerei.item.ModItems;
 import net.joefoxe.hexerei.tileentity.renderer.MixingCauldronRenderer;
 import net.minecraft.client.Minecraft;
@@ -46,7 +48,7 @@ import org.joml.Matrix4f;
 
 import java.util.List;
 
-public class BottlingRecipeCategory implements IRecipeCategory<BottlingRecipeJEI> {
+public class BottlingRecipeCategory implements IRecipeCategory<CauldronEmptyingRecipe> {
     public final static ResourceLocation UID = new ResourceLocation(Hexerei.MOD_ID, "bottling");
     public final static ResourceLocation TEXTURE =
             new ResourceLocation(Hexerei.MOD_ID, "textures/gui/bottling_gui_jei.png");
@@ -58,8 +60,8 @@ public class BottlingRecipeCategory implements IRecipeCategory<BottlingRecipeJEI
     }
 
     @Override
-    public RecipeType<BottlingRecipeJEI> getRecipeType() {
-        return new RecipeType<>(UID, BottlingRecipeJEI.class);
+    public RecipeType<CauldronEmptyingRecipe> getRecipeType() {
+        return new RecipeType<>(UID, CauldronEmptyingRecipe.class);
     }
 
     @Override
@@ -79,71 +81,72 @@ public class BottlingRecipeCategory implements IRecipeCategory<BottlingRecipeJEI
     }
 
     @Override
-    public void setRecipe(IRecipeLayoutBuilder builder, BottlingRecipeJEI recipe, IFocusGroup focuses) {
+    public void setRecipe(IRecipeLayoutBuilder builder, CauldronEmptyingRecipe recipe, IFocusGroup focuses) {
         builder.moveRecipeTransferButton(160, 90);
 
-        builder.addSlot(RecipeIngredientRole.INPUT,14, 24).addItemStack(recipe.getInput());
+        builder.addSlot(RecipeIngredientRole.INPUT,14, 24).addIngredients(recipe.getInput());
         builder.addSlot(RecipeIngredientRole.INPUT,62, 24)
-                .setFluidRenderer(2000, true, 16, 16)
-                .addFluidStack(recipe.getInputFluid().getFluid(), 250, recipe.getInputFluid().hasTag() ? recipe.getInputFluid().getTag() : new CompoundTag()).setOverlay(new IDrawable() {
-            @Override
-            public int getWidth() {
-                return 16;
-            }
+            .setFluidRenderer(2000, true, 16, 16)
+            .addIngredients(ForgeTypes.FLUID_STACK, recipe.getFluid().getMatchingFluidStacks())
+            .setOverlay(new IDrawable() {
+                    @Override
+                public int getWidth() {
+                    return 16;
+                }
 
-            @Override
-            public int getHeight() {
-                return 16;
-            }
+                @Override
+                public int getHeight() {
+                    return 16;
+                }
 
-            @Override
-            public void draw(GuiGraphics guiGraphics, int xOffset, int yOffset) {
+                @Override
+                public void draw(GuiGraphics guiGraphics, int xOffset, int yOffset) {
 
-                Lighting.setupFor3DItems();
-                RenderSystem.enableDepthTest();
-                guiGraphics.pose().pushPose();
+                    Lighting.setupFor3DItems();
+                    RenderSystem.enableDepthTest();
+                    guiGraphics.pose().pushPose();
 
-                guiGraphics.pose().translate(xOffset, yOffset, 0);
-                guiGraphics.pose().mulPoseMatrix(new Matrix4f().scale(1, -1, 1));
-                guiGraphics.pose().translate(-3, -15, 0);
-                guiGraphics.pose().scale(17, 17, 17);
-                MultiBufferSource.BufferSource buffer = Minecraft.getInstance().renderBuffers().bufferSource();
-                Vec3 rotationOffset = new Vec3(0, 0, 0);
+                    guiGraphics.pose().translate(xOffset, yOffset, 0);
+                    guiGraphics.pose().mulPoseMatrix(new Matrix4f().scale(1, -1, 1));
+                    guiGraphics.pose().translate(-3, -15, 0);
+                    guiGraphics.pose().scale(17, 17, 17);
+                    MultiBufferSource.BufferSource buffer = Minecraft.getInstance().renderBuffers().bufferSource();
+                    Vec3 rotationOffset = new Vec3(0, 0, 0);
 
-                float zRot = 0;
-                float xRot = 20;
-                float yRot = 30;
+                    float zRot = 0;
+                    float xRot = 20;
+                    float yRot = 30;
 
-                guiGraphics.pose().translate(rotationOffset.x, rotationOffset.y, rotationOffset.z);
-                guiGraphics.pose().mulPose(Axis.ZP.rotationDegrees(zRot));
-                guiGraphics.pose().mulPose(Axis.XP.rotationDegrees(xRot));
-                guiGraphics.pose().mulPose(Axis.YP.rotationDegrees(yRot));
-                guiGraphics.pose().translate(-rotationOffset.x, -rotationOffset.y, -rotationOffset.z);
+                    guiGraphics.pose().translate(rotationOffset.x, rotationOffset.y, rotationOffset.z);
+                    guiGraphics.pose().mulPose(Axis.ZP.rotationDegrees(zRot));
+                    guiGraphics.pose().mulPose(Axis.XP.rotationDegrees(xRot));
+                    guiGraphics.pose().mulPose(Axis.YP.rotationDegrees(yRot));
+                    guiGraphics.pose().translate(-rotationOffset.x, -rotationOffset.y, -rotationOffset.z);
 
-                BlockState blockState = ModBlocks.MIXING_CAULDRON.get().defaultBlockState().setValue(MixingCauldron.GUI_RENDER, true);
+                    BlockState blockState = ModBlocks.MIXING_CAULDRON.get().defaultBlockState().setValue(MixingCauldron.GUI_RENDER, true);
 
-                RenderSystem.setShaderTexture(0, InventoryMenu.BLOCK_ATLAS);
-                RenderSystem.enableBlend();
-                RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
-                RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
+                    RenderSystem.setShaderTexture(0, InventoryMenu.BLOCK_ATLAS);
+                    RenderSystem.enableBlend();
+                    RenderSystem.blendFunc(GlStateManager.SourceFactor.SRC_ALPHA, GlStateManager.DestFactor.ONE_MINUS_SRC_ALPHA);
+                    RenderSystem.setShaderColor(1.0F, 1.0F, 1.0F, 1.0F);
 
-                renderBlock(guiGraphics.pose(), buffer, LightTexture.FULL_BRIGHT, blockState, 0xFF404040);
+                    renderBlock(guiGraphics.pose(), buffer, LightTexture.FULL_BRIGHT, blockState, 0xFF404040);
 
-                MixingCauldronRenderer.renderFluidGUI(guiGraphics.pose(), buffer, recipe.getInputFluid(), 1, 1, OverlayTexture.NO_OVERLAY);
+                    MixingCauldronRenderer.renderFluidGUI(guiGraphics.pose(), buffer, recipe.getFluid().getMatchingFluidStacks().get(0), 1, 1, OverlayTexture.NO_OVERLAY);
 
-                guiGraphics.pose().popPose();
-            }
-        }, 0, 0);
+                    guiGraphics.pose().popPose();
+                }
+            }, 0, 0);
 
-        builder.addSlot(RecipeIngredientRole.OUTPUT, 96, 24).addItemStack(recipe.getOutput());
+        builder.addSlot(RecipeIngredientRole.OUTPUT, 96, 24).addItemStack(recipe.getResultItem());
 
     }
 
     @Override
-    public void draw(BottlingRecipeJEI recipe, IRecipeSlotsView view, GuiGraphics guiGraphics, double mouseX, double mouseY) {
+    public void draw(CauldronEmptyingRecipe recipe, IRecipeSlotsView view, GuiGraphics guiGraphics, double mouseX, double mouseY) {
 
         Minecraft minecraft = Minecraft.getInstance();
-        Component outputName = recipe.getOutput().getHoverName();
+        Component outputName = recipe.getResultItem().getHoverName();
 
 
 

--- a/src/main/java/net/joefoxe/hexerei/integration/jei/HexereiJei.java
+++ b/src/main/java/net/joefoxe/hexerei/integration/jei/HexereiJei.java
@@ -237,7 +237,7 @@ public class HexereiJei implements IModPlugin {
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.MIXING_CAULDRON.get()), new RecipeType<>(MixingCauldronRecipeCategory.UID, MixingCauldronRecipe.class));
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.MIXING_CAULDRON.get()), new RecipeType<>(FluidMixingRecipeCategory.UID, FluidMixingRecipe.class));
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.MIXING_CAULDRON.get()), new RecipeType<>(FluidMixingRecipeCategory.POTION_UID, FluidMixingRecipe.class));
-        registration.addRecipeCatalyst(new ItemStack(ModBlocks.MIXING_CAULDRON.get()), new RecipeType<>(BottlingRecipeCategory.UID, BottlingRecipeJEI.class));
+        registration.addRecipeCatalyst(new ItemStack(ModBlocks.MIXING_CAULDRON.get()), new RecipeType<>(BottlingRecipeCategory.UID, CauldronEmptyingRecipe.class));
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.MIXING_CAULDRON.get()), new RecipeType<>(BloodSigilRecipeCategory.UID, BloodSigilRecipeJEI.class));
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.MIXING_CAULDRON.get()), new RecipeType<>(DipperRecipeCategory.UID, DipperRecipe.class));
         registration.addRecipeCatalyst(new ItemStack(ModBlocks.CANDLE_DIPPER.get()), new RecipeType<>(DipperRecipeCategory.UID, DipperRecipe.class));
@@ -252,7 +252,7 @@ public class HexereiJei implements IModPlugin {
         registration.addRecipeClickArea(MixingCauldronScreen.class, 101, 41, 24, 24,
                 new RecipeType<>(MixingCauldronRecipeCategory.UID, MixingCauldronRecipe.class),
                 new RecipeType<>(FluidMixingRecipeCategory.UID, FluidMixingRecipe.class),
-                new RecipeType<>(BottlingRecipeCategory.UID, BottlingRecipeJEI.class),
+                new RecipeType<>(BottlingRecipeCategory.UID, CauldronEmptyingRecipe.class),
                 new RecipeType<>(BloodSigilRecipeCategory.UID, BloodSigilRecipeJEI.class),
                 new RecipeType<>(FluidMixingRecipeCategory.POTION_UID, FluidMixingRecipe.class));
 
@@ -363,8 +363,8 @@ public class HexereiJei implements IModPlugin {
         List<WoodcutterRecipe> woodcutter_recipes = rm.getAllRecipesFor(WoodcutterRecipe.Type.INSTANCE);
         registration.addRecipes(new RecipeType<>(WoodcutterRecipeCategory.UID, WoodcutterRecipe.class), woodcutter_recipes);
 
-        List<BottlingRecipeJEI> bottling_recipes = BottlingRecipeJEI.getRecipeList();
-        registration.addRecipes(new RecipeType<>(BottlingRecipeCategory.UID, BottlingRecipeJEI.class), bottling_recipes);
+        List<CauldronEmptyingRecipe> bottling_recipes = rm.getAllRecipesFor(ModRecipeTypes.CAULDRON_EMPTYING_TYPE.get());
+        registration.addRecipes(new RecipeType<>(BottlingRecipeCategory.UID, CauldronEmptyingRecipe.class), bottling_recipes);
 
         List<BloodSigilRecipeJEI> blood_sigil_recipes = BloodSigilRecipeJEI.getRecipeList();
         registration.addRecipes(new RecipeType<>(BloodSigilRecipeCategory.UID, BloodSigilRecipeJEI.class), blood_sigil_recipes);

--- a/src/main/java/net/joefoxe/hexerei/tileentity/MixingCauldronTile.java
+++ b/src/main/java/net/joefoxe/hexerei/tileentity/MixingCauldronTile.java
@@ -662,11 +662,7 @@ public class MixingCauldronTile extends RandomizableContainerBlockEntity impleme
                                 //for setting a cooldown on crafting so the animations can take place
                                 this.crafted = true;
                                 HexereiPacketHandler.instance.send(PacketDistributor.TRACKING_CHUNK.with(() -> level.getChunkAt(worldPosition)), new EmitParticlesPacket(worldPosition, 10, true));
-                                this.getFluidStack().shrink(iRecipe.getFluidLevelsConsumed());
-                                if (this.getFluidStack().getAmount() % 10 == 1)
-                                    this.getFluidStack().shrink(1);
-                                if (this.getFluidStack().getAmount() % 10 == 9)
-                                    this.getFluidStack().grow(1);
+                                normalizeTank();
                                 setChanged();
                             }
                         }
@@ -914,6 +910,14 @@ public class MixingCauldronTile extends RandomizableContainerBlockEntity impleme
         return amount;
     }
 
+    public void normalizeTank() {
+        if(this.getFluidStack().getAmount() % 10 == 1) {
+            this.getFluidStack().shrink(1);
+        }
+        if(this.getFluidStack().getAmount() % 10 == 9) {
+            this.getFluidStack().grow(1);
+        }
+    }
 
     @Nonnull
     @Override

--- a/src/main/resources/data/hexerei/recipes/cauldron_emptying/blood_to_bottle.json
+++ b/src/main/resources/data/hexerei/recipes/cauldron_emptying/blood_to_bottle.json
@@ -1,0 +1,14 @@
+{
+    "type": "hexerei:cauldron_emptying",
+    "input": {
+        "item": "minecraft:glass_bottle"
+    },
+    "fluid": {
+        "fluid": "hexerei:blood_fluid",
+        "amount": 250
+    },
+    "output": {
+        "item": "hexerei:blood_bottle",
+        "count": 1
+    }
+}

--- a/src/main/resources/data/hexerei/recipes/cauldron_emptying/lava_to_bottle.json
+++ b/src/main/resources/data/hexerei/recipes/cauldron_emptying/lava_to_bottle.json
@@ -1,0 +1,14 @@
+{
+    "type": "hexerei:cauldron_emptying",
+    "input": {
+        "item": "minecraft:glass_bottle"
+    },
+    "fluid": {
+        "fluid": "minecraft:lava",
+        "amount": 250
+    },
+    "output": {
+        "item": "hexerei:lava_bottle",
+        "count": 1
+    }
+}

--- a/src/main/resources/data/hexerei/recipes/cauldron_emptying/quicksilver_to_bottle.json
+++ b/src/main/resources/data/hexerei/recipes/cauldron_emptying/quicksilver_to_bottle.json
@@ -1,0 +1,14 @@
+{
+    "type": "hexerei:cauldron_emptying",
+    "input": {
+        "item": "minecraft:glass_bottle"
+    },
+    "fluid": {
+        "fluid": "hexerei:quicksilver_fluid",
+        "amount": 250
+    },
+    "output": {
+        "item": "hexerei:quicksilver_bottle",
+        "count": 1
+    }
+}

--- a/src/main/resources/data/hexerei/recipes/cauldron_emptying/tallow_to_bottle.json
+++ b/src/main/resources/data/hexerei/recipes/cauldron_emptying/tallow_to_bottle.json
@@ -1,0 +1,14 @@
+{
+    "type": "hexerei:cauldron_emptying",
+    "input": {
+        "item": "minecraft:glass_bottle"
+    },
+    "fluid": {
+        "fluid": "hexerei:tallow_fluid",
+        "amount": 250
+    },
+    "output": {
+        "item": "hexerei:tallow_bottle",
+        "count": 1
+    }
+}

--- a/src/main/resources/data/hexerei/recipes/cauldron_emptying/water_to_bottle.json
+++ b/src/main/resources/data/hexerei/recipes/cauldron_emptying/water_to_bottle.json
@@ -1,0 +1,17 @@
+{
+    "type": "hexerei:cauldron_emptying",
+    "input": {
+        "item": "minecraft:glass_bottle"
+    },
+    "fluid": {
+        "fluid": "minecraft:water",
+        "amount": 250
+    },
+    "output": {
+        "item": "minecraft:potion",
+        "count": 1,
+        "nbt": {
+            "Potion": "minecraft:water"
+        }
+    }
+}

--- a/src/main/resources/data/hexerei/recipes/cauldron_filling/blood_bottle.json
+++ b/src/main/resources/data/hexerei/recipes/cauldron_filling/blood_bottle.json
@@ -1,0 +1,14 @@
+{
+    "type": "hexerei:cauldron_filling",
+    "input": {
+        "item": "hexerei:blood_bottle"
+    },
+    "output": {
+        "item": "minecraft:glass_bottle",
+        "count": 1
+    },
+    "fluid": {
+        "fluid": "hexerei:blood_fluid",
+        "amount": 250
+    }
+}

--- a/src/main/resources/data/hexerei/recipes/cauldron_filling/lava_bottle.json
+++ b/src/main/resources/data/hexerei/recipes/cauldron_filling/lava_bottle.json
@@ -1,0 +1,14 @@
+{
+    "type": "hexerei:cauldron_filling",
+    "input": {
+        "item": "hexerei:lava_bottle"
+    },
+    "output": {
+        "item": "minecraft:glass_bottle",
+        "count": 1
+    },
+    "fluid": {
+        "fluid": "minecraft:lava",
+        "amount": 250
+    }
+}

--- a/src/main/resources/data/hexerei/recipes/cauldron_filling/quicksilver_bottle.json
+++ b/src/main/resources/data/hexerei/recipes/cauldron_filling/quicksilver_bottle.json
@@ -1,0 +1,14 @@
+{
+    "type": "hexerei:cauldron_filling",
+    "input": {
+        "item": "hexerei:quicksilver_bottle"
+    },
+    "output": {
+        "item": "minecraft:glass_bottle",
+        "count": 1
+    },
+    "fluid": {
+        "fluid": "hexerei:quicksilver_fluid",
+        "amount": 250
+    }
+}

--- a/src/main/resources/data/hexerei/recipes/cauldron_filling/tallow_bottle.json
+++ b/src/main/resources/data/hexerei/recipes/cauldron_filling/tallow_bottle.json
@@ -1,0 +1,14 @@
+{
+    "type": "hexerei:cauldron_filling",
+    "input": {
+        "item": "hexerei:tallow_bottle"
+    },
+    "output": {
+        "item": "minecraft:glass_bottle",
+        "count": 1
+    },
+    "fluid": {
+        "fluid": "hexerei:tallow_fluid",
+        "amount": 250
+    }
+}

--- a/src/main/resources/data/hexerei/recipes/cauldron_filling/water_bottle.json
+++ b/src/main/resources/data/hexerei/recipes/cauldron_filling/water_bottle.json
@@ -1,0 +1,17 @@
+{
+    "type": "hexerei:cauldron_filling",
+    "input": {
+        "item": "minecraft:potion",
+        "nbt": {
+            "Potion": "minecraft:water"
+        }
+    },
+    "output": {
+        "item": "minecraft:glass_bottle",
+        "count": 1
+    },
+    "fluid": {
+        "fluid": "minecraft:water",
+        "amount": 250
+    }
+}


### PR DESCRIPTION
This PR allows for right click filling/emptying interactions to be defined by JSON, in the form of recipes. `hexerei:cauldron_filling` fills the cauldron with fluid, while `hexerei:cauldron_emptying` empties the cauldron of some fluid. This makes it significantly easier to add new right click interactions for the mixing cauldron, for both modders and modpack developers.

Examples:

Recipe to fill the cauldron with water from a water bottle.
```json
{
    "type": "hexerei:cauldron_filling",
    "input": {
        "item": "minecraft:potion",
        "nbt": {
            "Potion": "minecraft:water"
        }
    },
    "output": {
        "item": "minecraft:glass_bottle",
        "count": 1
    },
    "fluid": {
        "fluid": "minecraft:water",
        "amount": 250
    }
}
```

Water to empty water from the cauldron into a water bottle.
```json
{
    "type": "hexerei:cauldron_emptying",
    "input": {
        "item": "minecraft:glass_bottle"
    },
    "fluid": {
        "fluid": "minecraft:water",
        "amount": 250
    },
    "output": {
        "item": "minecraft:potion",
        "count": 1,
        "nbt": {
            "Potion": "minecraft:water"
        }
    }
}
```

This PR also modifies the `BottlingRecipeCategory` JEI category to use emptying recipes. No filling recipe JEI category was made as it didn't seem necessary. The PR also makes a minor change, changing the sound when you empty the cauldron into a glass bottle from `SoundEvents.BOTTLE_EMPTY` to `SoundEvents.BOTTLE_FILL` (I assumed this was a bug).

Note: I didn't delete the `BottlingRecipeJEI` class, but it now has no uses and is safe to be deleted. Also, I decided to split it into *two* recipes as there may be an instance where it is desired for the resulting item from each direction of interaction to be different (Create has a similar system that does this too, though this code is not based on Create's).