### PR TITLE
Fixed Out of Bounds Exception causing crash when rendering the dipper

### DIFF
--- a/src/main/java/net/joefoxe/hexerei/tileentity/renderer/CandleDipperRenderer.java
+++ b/src/main/java/net/joefoxe/hexerei/tileentity/renderer/CandleDipperRenderer.java
@@ -204,11 +204,11 @@ public class CandleDipperRenderer implements BlockEntityRenderer<CandleDipperTil
             matrixStackIn.pushPose();
             matrixStackIn.translate(tileEntityIn.dipperSlots.get(2).pos.x(), tileEntityIn.dipperSlots.get(2).pos.y(), tileEntityIn.dipperSlots.get(2).pos.z());
             matrixStackIn.mulPose(Axis.YP.rotationDegrees(rotation));
-            if(tileEntityIn.dipperSlots.get(3).timesDipped == 1)
+            if(tileEntityIn.dipperSlots.get(2).timesDipped == 1)
                 renderBlock(matrixStackIn, bufferIn, combinedLightIn, ModBlocks.CANDLE_DIPPER_CANDLE_1.get().defaultBlockState());
-            if(tileEntityIn.dipperSlots.get(3).timesDipped == 2)
+            if(tileEntityIn.dipperSlots.get(2).timesDipped == 2)
                 renderBlock(matrixStackIn, bufferIn, combinedLightIn, ModBlocks.CANDLE_DIPPER_CANDLE_2.get().defaultBlockState());
-            if(tileEntityIn.dipperSlots.get(3).timesDipped == 3)
+            if(tileEntityIn.dipperSlots.get(2).timesDipped == 3)
                 renderBlock(matrixStackIn, bufferIn, combinedLightIn, ModBlocks.CANDLE_DIPPER_CANDLE_3.get().defaultBlockState());
             matrixStackIn.popPose();
         }


### PR DESCRIPTION
Fixed an OutOfBoundsException encountered when rendering items on the dipper.
Should resolve this issue here: https://github.com/JoeFoxe/Hexerei-1.19/issues/113#issue-2753628729

Tested both on gradle debug build and by replacing the official version of the mod with the fixed build on the world+modpack I first encountered this issue.