### PR TITLE
Update CandleData.java

### DIFF
--- a/src/main/java/net/joefoxe/hexerei/data/candle/CandleData.java
+++ b/src/main/java/net/joefoxe/hexerei/data/candle/CandleData.java
@@ -27,7 +27,7 @@ public class CandleData {
     public int height;
     public boolean lit;
     public float meltTimer;
-    public static int meltTimerMAX = 100;
+    public static int meltTimerMAX = 6000; // Sets the time to be 5 minutes instead of 5 seconds. This results in the 35mins total burn time.
     public int dyeColor;
     public int cooldown;
     public CandleLayer base;


### PR DESCRIPTION
Fixes the bug where the candle burns too quickly.
Changed the value meltTimerMAX to be 6000 ticks (5mins) instead of 100 ticks (5secs) resulting in the intended 35mins burn time.

You may have already changed this for a future version to come but hey.