### PR TITLE
1.21.1 - fix spectator right click crashes

### DIFF
--- a/src/main/java/net/joefoxe/hexerei/block/custom/CandleDipper.java
+++ b/src/main/java/net/joefoxe/hexerei/block/custom/CandleDipper.java
@@ -46,7 +46,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Stream;
 
-public class CandleDipper extends BaseEntityBlock implements ITileEntity<CandleDipperTile>, EntityBlock, SimpleWaterloggedBlock {
+public class CandleDipper extends Block implements ITileEntity<CandleDipperTile>, EntityBlock, SimpleWaterloggedBlock {
     public static final MapCodec<CandleDipper> CODEC = simpleCodec(CandleDipper::new);
 
     public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
@@ -132,7 +132,7 @@ public class CandleDipper extends BaseEntityBlock implements ITileEntity<CandleD
     }
 
     @Override
-    protected MapCodec<? extends BaseEntityBlock> codec() {
+    protected MapCodec<? extends Block> codec() {
         return CODEC;
     }
 
@@ -229,5 +229,10 @@ public class CandleDipper extends BaseEntityBlock implements ITileEntity<CandleD
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level world, BlockState state, BlockEntityType<T> entityType){
         return entityType == ModTileEntities.CANDLE_DIPPER_TILE.get() ?
                 (world2, pos, state2, entity) -> ((CandleDipperTile)entity).tick() : null;
+    }
+
+    @Nullable
+    protected static <E extends BlockEntity, A extends BlockEntity> BlockEntityTicker<A> createTickerHelper(BlockEntityType<A> serverType, BlockEntityType<E> clientType, BlockEntityTicker<? super E> ticker) {
+        return clientType == serverType ? (BlockEntityTicker<A>)ticker : null;
     }
 }

--- a/src/main/java/net/joefoxe/hexerei/block/custom/Coffer.java
+++ b/src/main/java/net/joefoxe/hexerei/block/custom/Coffer.java
@@ -62,7 +62,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.Optional;
 
-public class Coffer extends BaseEntityBlock implements ITileEntity<CofferTile>, SimpleWaterloggedBlock {
+public class Coffer extends Block implements ITileEntity<CofferTile>, SimpleWaterloggedBlock, EntityBlock {
     public static final MapCodec<Coffer> CODEC = simpleCodec(Coffer::new);
 
     public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
@@ -73,7 +73,7 @@ public class Coffer extends BaseEntityBlock implements ITileEntity<CofferTile>, 
     }
 
     @Override
-    protected MapCodec<? extends BaseEntityBlock> codec() {
+    protected MapCodec<? extends Block> codec() {
         return CODEC;
     }
 

--- a/src/main/java/net/joefoxe/hexerei/block/custom/CourierPackage.java
+++ b/src/main/java/net/joefoxe/hexerei/block/custom/CourierPackage.java
@@ -28,6 +28,8 @@ import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
 import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.entity.BlockEntityTicker;
+import net.minecraft.world.level.block.entity.BlockEntityType;
 import net.minecraft.world.level.block.state.BlockState;
 import net.minecraft.world.level.block.state.StateDefinition;
 import net.minecraft.world.level.block.state.properties.BlockStateProperties;
@@ -47,7 +49,7 @@ import javax.annotation.Nullable;
 import java.util.List;
 import java.util.stream.Stream;
 
-public class CourierPackage extends BaseEntityBlock implements ITileEntity<CourierPackageTile>, SimpleWaterloggedBlock {
+public class CourierPackage extends Block implements ITileEntity<CourierPackageTile>, SimpleWaterloggedBlock, EntityBlock {
     public static final BooleanProperty WATERLOGGED = BlockStateProperties.WATERLOGGED;
     public static final EnumProperty<State> STATE = EnumProperty.create("state", State.class);
 
@@ -92,7 +94,7 @@ public class CourierPackage extends BaseEntityBlock implements ITileEntity<Couri
     }
 
     @Override
-    protected MapCodec<? extends BaseEntityBlock> codec() {
+    protected MapCodec<? extends Block> codec() {
         return CODEC;
     }
 
@@ -231,5 +233,10 @@ public class CourierPackage extends BaseEntityBlock implements ITileEntity<Couri
     @Override
     public BlockEntity newBlockEntity(BlockPos pPos, BlockState pState) {
         return new CourierPackageTile(ModTileEntities.COURIER_PACKAGE_TILE.get(), pPos, pState);
+    }
+
+    @Nullable
+    protected static <E extends BlockEntity, A extends BlockEntity> BlockEntityTicker<A> createTickerHelper(BlockEntityType<A> serverType, BlockEntityType<E> clientType, BlockEntityTicker<? super E> ticker) {
+        return clientType == serverType ? (BlockEntityTicker<A>)ticker : null;
     }
 }

--- a/src/main/java/net/joefoxe/hexerei/block/custom/MixingCauldron.java
+++ b/src/main/java/net/joefoxe/hexerei/block/custom/MixingCauldron.java
@@ -54,10 +54,7 @@ import net.minecraft.world.level.BlockGetter;
 import net.minecraft.world.level.Level;
 import net.minecraft.world.level.LevelAccessor;
 import net.minecraft.world.level.LevelReader;
-import net.minecraft.world.level.block.BaseEntityBlock;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.block.PointedDripstoneBlock;
-import net.minecraft.world.level.block.RenderShape;
+import net.minecraft.world.level.block.*;
 import net.minecraft.world.level.block.entity.BlockEntity;
 import net.minecraft.world.level.block.entity.BlockEntityTicker;
 import net.minecraft.world.level.block.entity.BlockEntityType;
@@ -93,7 +90,7 @@ import static net.joefoxe.hexerei.tileentity.renderer.MixingCauldronRenderer.MIN
 import static net.minecraft.world.level.block.state.properties.BlockStateProperties.LIT;
 
 @SuppressWarnings("deprecation")
-public class MixingCauldron extends BaseEntityBlock implements ITileEntity<MixingCauldronTile> {
+public class MixingCauldron extends Block implements ITileEntity<MixingCauldronTile>, EntityBlock {
 
     //Moved to constant in case this is changed in the future.
     public static final int POTION_MB_AMOUNT = 250;
@@ -610,5 +607,10 @@ public class MixingCauldron extends BaseEntityBlock implements ITileEntity<Mixin
     public <T extends BlockEntity> BlockEntityTicker<T> getTicker(Level world, BlockState state, BlockEntityType<T> entityType) {
         return entityType == ModTileEntities.MIXING_CAULDRON_TILE.get() ?
                 (world2, pos, state2, entity) -> ((MixingCauldronTile) entity).tick() : null;
+    }
+
+    @Nullable
+    protected static <E extends BlockEntity, A extends BlockEntity> BlockEntityTicker<A> createTickerHelper(BlockEntityType<A> serverType, BlockEntityType<E> clientType, BlockEntityTicker<? super E> ticker) {
+        return clientType == serverType ? (BlockEntityTicker<A>)ticker : null;
     }
 }

--- a/src/main/java/net/joefoxe/hexerei/container/ModContainers.java
+++ b/src/main/java/net/joefoxe/hexerei/container/ModContainers.java
@@ -71,8 +71,13 @@ public class ModContainers {
     public static final DeferredHolder<MenuType<?>, MenuType<BroomContainer>> BROOM_CONTAINER = CONTAINERS.register("broom_container",
             () -> new MenuType<>((IContainerFactory<BroomContainer>) (windowId, inv, data) -> {
                 Level world = inv.player.level();//new BroomEntity(world, pos.getX(), pos.getY(), pos.getZ())
-                int id = data.readInt();
+
+                if (data == null) {
+                    return new BroomContainer(windowId,new BroomEntity(world, 0, 0, 0), inv, inv.player, false);
+                }
+
                 boolean isEnder = data.readBoolean();
+                int id = data.readInt();
                 if(world.getEntity(id) != null)
                     return new BroomContainer(windowId,(BroomEntity)world.getEntity(id), inv, inv.player, isEnder);
                 else


### PR DESCRIPTION
Found out that if you're in spectator mode and right click some of the objects (most of them extended from BaseEntityBlock), it would cause a crash because the FriendlyByteBuf is null in those cases.